### PR TITLE
Enable experimental decorators in TypeScript configuration

### DIFF
--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -9,6 +9,8 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   }
 }


### PR DESCRIPTION
This PR modifies the TypeScript configuration file `tsconfig.base.json` to enable experimental decorators by adding `experimentalDecorators` and `emitDecoratorMetadata` options. These changes are necessary for projects utilizing decorators in their TypeScript code, ensuring that the compile process recognizes and handles them correctly.

---

> This pull request was co-created with Cosine Genie

Original Task: [cart/52l151tsqex6](https://cosine.sh/g1x6mo2fheck/cart/task/52l151tsqex6)
Author: Tapan Radadiya
