### PR TITLE
Fix Multer Type Import in Upload Controller and Service

### DIFF
--- a/packages/backend/src/upload/upload.controller.ts
+++ b/packages/backend/src/upload/upload.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, UploadedFile, UseInterceptors, Body, Req, Res, UseGua
 import { FileInterceptor } from '@nestjs/platform-express';
 import { UploadService } from './upload.service';
 import { Request, Response } from 'express';
+import { File as MulterFile } from 'multer';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @UseGuards(JwtAuthGuard)
@@ -12,7 +13,7 @@ export class UploadController {
   @Post()
   @UseInterceptors(FileInterceptor('file'))
   async uploadFile(
-    @UploadedFile() file: Express.Multer.File,
+    @UploadedFile() file: MulterFile,
     @Body('projectId') projectId: string,
     @Res() res: Response,
   ) {

--- a/packages/backend/src/upload/upload.service.ts
+++ b/packages/backend/src/upload/upload.service.ts
@@ -5,11 +5,13 @@ import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { mkdirp } from 'mkdirp';
 
+import { File as MulterFile } from 'multer';
+
 @Injectable()
 export class UploadService {
   constructor(private prisma: PrismaService) {}
 
-  async handleUpload(file: Express.Multer.File, projectId: string) {
+  async handleUpload(file: MulterFile, projectId: string) {
     const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
     if (!file) throw new BadRequestException('No file uploaded');


### PR DESCRIPTION
This pull request addresses the TypeScript error `Namespace 'global.Express' has no exported member 'Multer'.ts(2694)` encountered in the `upload.controller.ts` file. The error was caused by using `Express.Multer.File` instead of importing the correct type from Multer. 

Changes made:
- Import the `File` type as `MulterFile` from the 'multer' package in both `upload.controller.ts` and `upload.service.ts`.
- Update the method signatures in both files to use the `MulterFile` type instead of `Express.Multer.File`.

These changes ensure that the Multer file type is correctly utilized, resolving the TypeScript error.

---

> This pull request was co-created with Cosine Genie

Original Task: [cart/fvlcd8u6igsc](https://cosine.sh/g1x6mo2fheck/cart/task/fvlcd8u6igsc)
Author: Tapan Radadiya
